### PR TITLE
Port to TrombLoader 2

### DIFF
--- a/Compatibility/AutoTootCompatibility.cs
+++ b/Compatibility/AutoTootCompatibility.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Linq;
-using System.Reflection;
 
 namespace TootTally.Compatibility
 {

--- a/Compatibility/HoverTootCompatibility.cs
+++ b/Compatibility/HoverTootCompatibility.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Linq;
-using System.Reflection;
 
 namespace TootTally.Compatibility
 {

--- a/CustomLeaderboard/GlobalLeaderboard.cs
+++ b/CustomLeaderboard/GlobalLeaderboard.cs
@@ -1,24 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
-using HarmonyLib;
-using System.IO;
 using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
-using TootTally.Replays;
-using TrombLoader.Helpers;
-using UnityEngine;
-using UnityEngine.Bindings;
-using UnityEngine.Networking;
-using UnityEngine.Networking.Match;
-using UnityEngine.Playables;
-using UnityEngine.SocialPlatforms.Impl;
-using UnityEngine.UI;
+using BaboonAPI.Hooks.Tracks;
 using TootTally.Graphics;
 using TootTally.Utils;
-using UnityEngine.EventSystems;
 using TootTally.Utils.Helpers;
+using TrombLoader.CustomTracks;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.Networking;
+using UnityEngine.UI;
 
 namespace TootTally.CustomLeaderboard
 {
@@ -104,7 +95,7 @@ namespace TootTally.CustomLeaderboard
             _diffRatingMaskRectangle.sizeDelta = new Vector2(0, 30);
             diffStarsHolder.AddComponent<Mask>();
             Image imageMask = diffStarsHolder.AddComponent<Image>();
-            imageMask.color = new Color(0, 0, 0, 0.01f); //if set at 0 stars wont display ?__? 
+            imageMask.color = new Color(0, 0, 0, 0.01f); //if set at 0 stars wont display ?__?
             diffBar.GetComponent<RectTransform>().sizeDelta += new Vector2(41.5f, 0);
             _diffRating = GameObjectFactory.CreateSingleText(diffBar.transform, "diffRating", "", GameTheme.themeColors.leaderboard.text);
             _diffRating.gameObject.GetComponent<Outline>().effectColor = GameTheme.themeColors.leaderboard.textOutline;
@@ -152,13 +143,13 @@ namespace TootTally.CustomLeaderboard
             _globalLeaderboard.SetActive(true); //for some reasons its needed to display the leaderboard
             _scrollAcceleration = 0;
 
-            string trackRef = ___alltrackslist[_levelSelectControllerInstance.songindex].trackref;
-            bool isCustom = Globals.IsCustomTrack(trackRef);
-            string songHash = GetChoosenSongHash(trackRef);
+            var trackRef = ___alltrackslist[_levelSelectControllerInstance.songindex].trackref;
+            var track = TrackLookup.lookup(trackRef);
+            var songHash = SongDataHelper.GetSongHash(track);
 
             if (_currentLeaderboardCoroutines.Count != 0) CancelAndClearAllCoroutineInList();
 
-            _currentLeaderboardCoroutines.Add(TootTallyAPIService.GetHashInDB(songHash, isCustom, (songHashInDB) =>
+            _currentLeaderboardCoroutines.Add(TootTallyAPIService.GetHashInDB(songHash, track is CustomTrack, (songHashInDB) =>
             {
                 if (songHashInDB == 0)
                 {
@@ -335,12 +326,6 @@ namespace TootTally.CustomLeaderboard
                 _loadingSwirly.GetComponent<RectTransform>().Rotate(0, 0, 1000 * Time.deltaTime * SWIRLY_SPEED);
         }
 
-        private static string GetChoosenSongHash(string trackRef)
-        {
-            bool isCustom = Globals.IsCustomTrack(trackRef);
-            return isCustom ? GetSongHash(trackRef) : trackRef;
-        }
-
         private void SetTabsImages()
         {
             for (int i = 0; i < 3; i++)
@@ -354,14 +339,6 @@ namespace TootTally.CustomLeaderboard
 
             }
             _tabs.SetActive(true);
-        }
-
-        private static string GetSongHash(string trackRef) => SongDataHelper.CalcFileHash(GetSongFilePath(true, trackRef));
-        private static string GetSongFilePath(bool isCustom, string trackRef)
-        {
-            return isCustom ?
-                Path.Combine(Globals.ChartFolders[trackRef], "song.tmb") :
-                $"{Application.streamingAssetsPath}/leveldata/{trackRef}.tmb";
         }
 
         public enum LeaderboardState

--- a/CustomLeaderboard/GlobalLeaderboard.cs
+++ b/CustomLeaderboard/GlobalLeaderboard.cs
@@ -149,7 +149,7 @@ namespace TootTally.CustomLeaderboard
 
             if (_currentLeaderboardCoroutines.Count != 0) CancelAndClearAllCoroutineInList();
 
-            _currentLeaderboardCoroutines.Add(TootTallyAPIService.GetHashInDB(songHash, track is CustomTrack, (songHashInDB) =>
+            _currentLeaderboardCoroutines.Add(TootTallyAPIService.GetHashInDB(songHash, track is CustomTrack, songHashInDB =>
             {
                 if (songHashInDB == 0)
                 {
@@ -164,7 +164,7 @@ namespace TootTally.CustomLeaderboard
                     _currentSelectedSongHash = songHashInDB;
                 _songData = null;
                 _scoreDataList = null;
-                _currentLeaderboardCoroutines.Add(TootTallyAPIService.GetSongDataFromDB(songHashInDB, (songData) =>
+                _currentLeaderboardCoroutines.Add(TootTallyAPIService.GetSongDataFromDB(songHashInDB, songData =>
                 {
                     if (songData != null)
                     {
@@ -187,7 +187,7 @@ namespace TootTally.CustomLeaderboard
                         CancelAndClearAllCoroutineInList();
                 }));
                 Plugin.Instance.StartCoroutine(_currentLeaderboardCoroutines.Last());
-                _currentLeaderboardCoroutines.Add(TootTallyAPIService.GetLeaderboardScoresFromDB(songHashInDB, (scoreDataList) =>
+                _currentLeaderboardCoroutines.Add(TootTallyAPIService.GetLeaderboardScoresFromDB(songHashInDB, scoreDataList =>
                 {
                     if (scoreDataList != null)
                     {

--- a/CustomLeaderboard/GlobalLeaderboardManager.cs
+++ b/CustomLeaderboard/GlobalLeaderboardManager.cs
@@ -1,22 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using HarmonyLib;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
-using TootTally.Replays;
-using TrombLoader.Helpers;
 using UnityEngine;
-using UnityEngine.Bindings;
-using UnityEngine.Networking;
-using UnityEngine.Networking.Match;
-using UnityEngine.Playables;
-using UnityEngine.SocialPlatforms.Impl;
-using UnityEngine.UI;
-using TootTally.Graphics;
-using TootTally.Utils;
 
 namespace TootTally.CustomLeaderboard
 {

--- a/CustomLeaderboard/LeaderboardRowEntry.cs
+++ b/CustomLeaderboard/LeaderboardRowEntry.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using TootTally.Graphics;
+﻿using TootTally.Graphics;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/DiscordRichPresence/Core/ActivityManager.cs
+++ b/DiscordRichPresence/Core/ActivityManager.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace TootTally.Discord.Core
+﻿namespace TootTally.Discord.Core
 {
     public partial class ActivityManager
     {

--- a/DiscordRichPresence/Core/Constants.cs
+++ b/DiscordRichPresence/Core/Constants.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace TootTally.Discord.Core
+﻿namespace TootTally.Discord.Core
 {
     static class Constants
     {

--- a/DiscordRichPresence/Core/ImageManager.cs
+++ b/DiscordRichPresence/Core/ImageManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 #if UNITY_EDITOR || UNITY_STANDALONE
 using UnityEngine;
 #endif

--- a/DiscordRichPresence/Core/LobbyManager.cs
+++ b/DiscordRichPresence/Core/LobbyManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Text;
 

--- a/DiscordRichPresence/Core/StorageManager.cs
+++ b/DiscordRichPresence/Core/StorageManager.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace TootTally.Discord.Core
 {

--- a/DiscordRichPresence/Core/StoreManager.cs
+++ b/DiscordRichPresence/Core/StoreManager.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Runtime.InteropServices;
 using System.Collections.Generic;
-using System.Text;
 
 namespace TootTally.Discord.Core
 {

--- a/DiscordRichPresence/DiscordRichPresence.cs
+++ b/DiscordRichPresence/DiscordRichPresence.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using HarmonyLib;
 using TootTally.Discord.Core;
 

--- a/DiscordRichPresence/GameStatus.cs
+++ b/DiscordRichPresence/GameStatus.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections;
-
 namespace TootTally.Discord;
 
 public enum GameStatus

--- a/Graphics/BetterScrollSpeedSliderPatcher.cs
+++ b/Graphics/BetterScrollSpeedSliderPatcher.cs
@@ -1,11 +1,6 @@
-﻿using BepInEx;
+﻿using System.IO;
+using BepInEx;
 using BepInEx.Configuration;
-using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using TootTally.Utils;
 using TootTally.Utils.Helpers;
 using UnityEngine;
 using UnityEngine.UI;

--- a/Graphics/CustomButton.cs
+++ b/Graphics/CustomButton.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UI;
 
 namespace TootTally.Graphics

--- a/Graphics/GameObjectFactory.cs
+++ b/Graphics/GameObjectFactory.cs
@@ -1,7 +1,5 @@
-﻿using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
+using HarmonyLib;
 using TootTally.CustomLeaderboard;
 using TootTally.Replays;
 using TootTally.Utils;

--- a/Graphics/GameTheme.cs
+++ b/Graphics/GameTheme.cs
@@ -1,12 +1,10 @@
-﻿using BepInEx;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.IO;
-using System.Text;
+using BepInEx;
+using Newtonsoft.Json;
 using TootTally.Utils;
 using UnityEngine;
 using UnityEngine.UI;
-using Newtonsoft.Json;
 
 namespace TootTally.Graphics
 {

--- a/Graphics/GameThemeManager.cs
+++ b/Graphics/GameThemeManager.cs
@@ -1,10 +1,7 @@
-﻿using BepInEx;
+﻿using System.IO;
+using BepInEx;
 using BepInEx.Configuration;
 using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using TootTally.Utils;
 using TootTally.Utils.Helpers;
 using UnityEngine;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,24 +1,12 @@
 ﻿using BepInEx;
+using BepInEx.Bootstrap;
 using BepInEx.Configuration;
 using HarmonyLib;
-using UnityEngine;
-using UnityEngine.Networking;
-using System;
-using System.Linq;
-using System.IO;
-using System.Collections.Generic;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Security.Cryptography;
-using System.Text;
-using TrombLoader.Helpers;
-using UnityEngine.UI;
+using TootTally.CustomLeaderboard;
+using TootTally.Discord;
 using TootTally.Graphics;
 using TootTally.Replays;
 using TootTally.Utils;
-using TootTally.CustomLeaderboard;
-using TootTally.Utils.Helpers;
-using TootTally.Discord;
-using BepInEx.Bootstrap;
 
 namespace TootTally
 {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -92,13 +92,13 @@ namespace TootTally
             {
                 if (userInfo == null)
                 {
-                    Instance.StartCoroutine(TootTallyAPIService.GetUser((user) =>
+                    Instance.StartCoroutine(TootTallyAPIService.GetUser(user =>
                     {
                         if (user != null)
                             OnUserLogin(user);
                     }));
 
-                    Instance.StartCoroutine(ThunderstoreAPIService.GetMostRecentModVersion((version) =>
+                    Instance.StartCoroutine(ThunderstoreAPIService.GetMostRecentModVersion(version =>
                     {
                         if (version.CompareTo(PluginInfo.PLUGIN_VERSION) > 0)
                         {
@@ -114,7 +114,7 @@ namespace TootTally
             {
                 //in case they failed to login. Try logging in again
                 if (userInfo == null || userInfo.username == "Guest")
-                    Instance.StartCoroutine(TootTallyAPIService.GetUser((user) =>
+                    Instance.StartCoroutine(TootTallyAPIService.GetUser(user =>
                     {
                         if (user != null)
                             OnUserLogin(user);
@@ -124,7 +124,7 @@ namespace TootTally
             private static void OnUserLogin(SerializableClass.User user)
             {
                 userInfo = user;
-                Instance.StartCoroutine(TootTallyAPIService.SendModInfo(Chainloader.PluginInfos, (allowSubmit) =>
+                Instance.StartCoroutine(TootTallyAPIService.SendModInfo(Chainloader.PluginInfos, allowSubmit =>
                 {
                     userInfo.allowSubmit = allowSubmit;
                 }));

--- a/Replays/NewReplaySystem.cs
+++ b/Replays/NewReplaySystem.cs
@@ -125,8 +125,7 @@ namespace TootTally.Replays
             }
             else
             {
-                var filePath = $"{Application.streamingAssetsPath}/leveldata/{trackRef}.tmb";
-                var tmb = SongDataHelper.GenerateBaseTmb(filePath);
+                var tmb = SongDataHelper.GenerateBaseTmb(track);
                 songHash = SongDataHelper.CalcSHA256Hash(Encoding.UTF8.GetBytes(tmb));
             }
 

--- a/Replays/NewReplaySystem.cs
+++ b/Replays/NewReplaySystem.cs
@@ -1,14 +1,15 @@
-﻿using BepInEx;
-using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using BaboonAPI.Hooks.Tracks;
+using BepInEx;
+using Newtonsoft.Json;
 using TootTally.Graphics;
 using TootTally.Utils;
 using TootTally.Utils.Helpers;
-using TrombLoader.Helpers;
+using TrombLoader.CustomTracks;
 using UnityEngine;
 
 namespace TootTally.Replays
@@ -114,18 +115,20 @@ namespace TootTally.Replays
 
         public string GetRecordedReplayJson(string uuid, float targetFramerate)
         {
-            string songNameLong = GlobalVariables.chosen_track_data.trackname_long;
-            string trackRef = GlobalVariables.chosen_track_data.trackref;
-            bool isCustom = Globals.IsCustomTrack(trackRef);
+            var trackRef = GlobalVariables.chosen_track_data.trackref;
+            var track = TrackLookup.lookup(trackRef);
             string songHash;
-            if (!isCustom)
+
+            if (track is CustomTrack)
             {
-                string songFilePath = SongDataHelper.GetSongFilePath(trackRef);
-                string tmb = SongDataHelper.GenerateBaseTmb(songFilePath);
-                songHash = SongDataHelper.CalcSHA256Hash(Encoding.UTF8.GetBytes(tmb));
+                songHash = SongDataHelper.GetSongHash(track);
             }
             else
-                songHash = SongDataHelper.GetSongHash(trackRef);
+            {
+                var filePath = $"{Application.streamingAssetsPath}/leveldata/{trackRef}.tmb";
+                var tmb = SongDataHelper.GenerateBaseTmb(filePath);
+                songHash = SongDataHelper.CalcSHA256Hash(Encoding.UTF8.GetBytes(tmb));
+            }
 
             string username = Plugin.userInfo.username;
 
@@ -139,7 +142,7 @@ namespace TootTally.Replays
             replayJson.endtime = endDateTimeUnix;
             replayJson.uuid = uuid;
             replayJson.input = inputType;
-            replayJson.song = songNameLong;
+            replayJson.song = track.trackname_long;
             replayJson.samplerate = targetFramerate;
             replayJson.scrollspeed = GlobalVariables.gamescrollspeed;
             replayJson.pluginbuilddate = Plugin.BUILDDATE;
@@ -268,7 +271,7 @@ namespace TootTally.Replays
         {
             var newCursorPosition = EasingHelper.Lerp(_lastPosition, _nextPositionTarget, (_lastTiming - currentMapPosition) / (_lastTiming - _nextTimingTarget));
             SetCursorPosition(__instance, newCursorPosition);
-            __instance.puppet_humanc.doPuppetControl(-newCursorPosition / 225); //225 is half of the Gameplay area:450 
+            __instance.puppet_humanc.doPuppetControl(-newCursorPosition / 225); //225 is half of the Gameplay area:450
         }
 
         private void PlaybackFrameData(float currentMapPosition, GameController __instance)
@@ -278,10 +281,10 @@ namespace TootTally.Replays
                 _lastTiming = _frameData[_frameIndex][(int)FrameDataStructure.NoteHolder];
                 _lastPosition = _frameData[_frameIndex][(int)FrameDataStructure.PointerPosition] / 100f;
             }
-            
+
             while (_frameData.Count > _frameIndex && currentMapPosition <= _frameData[_frameIndex][(int)FrameDataStructure.NoteHolder]) //smaller or equal to because noteholder goes toward negative
             {
-                
+
                 if (_frameIndex < _frameData.Count - 1)
                 {
                     _nextTimingTarget = _frameData[_frameIndex + 1][(int)FrameDataStructure.NoteHolder];

--- a/Replays/ReplaySystemManager.cs
+++ b/Replays/ReplaySystemManager.cs
@@ -305,7 +305,7 @@ namespace TootTally.Replays
 
                 case NewReplaySystem.ReplayState.ReplayLoadNotFound:
                     PopUpNotifManager.DisplayNotif("Downloading replay...", GameTheme.themeColors.notification.defaultText);
-                    Plugin.Instance.StartCoroutine(TootTallyAPIService.DownloadReplay(replayId, (uuid) =>
+                    Plugin.Instance.StartCoroutine(TootTallyAPIService.DownloadReplay(replayId, uuid =>
                     {
                         ResolveLoadReplay(uuid, levelSelectControllerInstance);
                     }));
@@ -345,11 +345,11 @@ namespace TootTally.Replays
                     SerializableClass.TMBFile chart = new SerializableClass.TMBFile { tmb = tmb };
                     Plugin.Instance.StartCoroutine(TootTallyAPIService.AddChartInDB(chart, () =>
                     {
-                        Plugin.Instance.StartCoroutine(TootTallyAPIService.GetReplayUUID(SongDataHelper.GetChoosenSongHash(), (UUID) => _replayUUID = UUID));
+                        Plugin.Instance.StartCoroutine(TootTallyAPIService.GetReplayUUID(SongDataHelper.GetChoosenSongHash(), UUID => _replayUUID = UUID));
                     }));
                 }
                 else if (songHashInDB != 0)
-                    Plugin.Instance.StartCoroutine(TootTallyAPIService.GetReplayUUID(SongDataHelper.GetChoosenSongHash(), (UUID) => _replayUUID = UUID));
+                    Plugin.Instance.StartCoroutine(TootTallyAPIService.GetReplayUUID(SongDataHelper.GetChoosenSongHash(), UUID => _replayUUID = UUID));
 
 
             }));

--- a/Replays/ReplaySystemManager.cs
+++ b/Replays/ReplaySystemManager.cs
@@ -1,14 +1,15 @@
-﻿using BepInEx;
-using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using BaboonAPI.Hooks.Tracks;
+using BepInEx;
+using HarmonyLib;
 using TootTally.Compatibility;
 using TootTally.Graphics;
 using TootTally.Utils;
 using TootTally.Utils.Helpers;
-using TrombLoader.Helpers;
+using TrombLoader.CustomTracks;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.Scripting;
@@ -322,12 +323,13 @@ namespace TootTally.Replays
 
         public static void SetReplayUUID()
         {
-            string trackRef = GlobalVariables.chosen_track;
-            bool isCustom = Globals.IsCustomTrack(trackRef);
-            string songFilePath = SongDataHelper.GetSongFilePath(trackRef);
-            string songHash = isCustom ? SongDataHelper.CalcFileHash(songFilePath) : trackRef;
+            var trackRef = GlobalVariables.chosen_track;
+            var track = TrackLookup.lookup(trackRef);
 
-            StartAPICallCoroutine(songHash, songFilePath, isCustom);
+            StartAPICallCoroutine(
+                SongDataHelper.GetSongHash(track),
+                SongDataHelper.GetSongFilePath(track),
+                track is CustomTrack);
         }
 
         public static void StartAPICallCoroutine(string songHash, string songFilePath, bool isCustom)

--- a/TootTally.csproj
+++ b/TootTally.csproj
@@ -14,6 +14,7 @@
 		<PackageReference Include="BepInEx.Core" Version="5.*" />
 		<PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
 		<PackageReference Include="TromboneChamp.GameLibs" Version="1.9.5" />
+		<PackageReference Include="TromboneChamp.BaboonAPI" Version="2.2.0" />
 		<PackageReference Include="TromboneChamp.TrombLoader" Version="2.0.0-rc.1" />
 		<PackageReference Include="UnityEngine.Modules" Version="2019.4.40" />
 	</ItemGroup>

--- a/TootTally.csproj
+++ b/TootTally.csproj
@@ -7,15 +7,15 @@
 		<Version>0.2.9</Version>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<LangVersion>latest</LangVersion>
-		<TromboneChampDir>E:\SteamLibrary\steamapps\common\TromboneChamp</TromboneChampDir>
-		<TromboneTootDir>C:\Users\Sabz\AppData\Roaming\r2modmanPlus-local\TromboneChamp\profiles\Default/BepInEx/plugins/TootTally-TootTally</TromboneTootDir>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
 		<PackageReference Include="BepInEx.Core" Version="5.*" />
 		<PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-		<PackageReference Include="UnityEngine.Modules" Version="2019.3.11" IncludeAssets="compile" />
+		<PackageReference Include="TromboneChamp.GameLibs" Version="1.9.5" />
+		<PackageReference Include="TromboneChamp.TrombLoader" Version="2.0.0-rc.1" />
+		<PackageReference Include="UnityEngine.Modules" Version="2019.4.40" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
@@ -23,33 +23,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="0Harmony">
-			<HintPath>$(TromboneChampDir)\BepInEx\core\0Harmony.dll</HintPath>
-		</Reference>
-		<Reference Include="Assembly-CSharp">
-			<HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\Assembly-CSharp-nstrip.dll</HintPath>
-		</Reference>
-		<Reference Include="UnityEngine">
-			<HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.dll</HintPath>
-		</Reference>
-		<Reference Include="UnityEngine.CoreModule">
-			<HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-		</Reference>
-		<Reference Include="Unity.TextMeshPro">
-			<HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-		</Reference>
-		<Reference Include="UnityEngine.InputLegacyModule">
-			<HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
-		</Reference>
-		<Reference Include="UnityEngine.UI">
-			<HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.UI.dll</HintPath>
-		</Reference>
-		<Reference Include="Newtonsoft.Json">
-			<HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\Newtonsoft.Json.dll</HintPath>
-		</Reference>
-		<Reference Include="TrombLoader">
-			<HintPath>$(TromboneChampDir)\BepInEx\plugins\TrombLoader.dll</HintPath>
-		</Reference>
 		<Reference Include="AutoToot">
 			<HintPath>$(TromboneChampDir)\BepInEx\plugins\AutoToot.dll</HintPath>
 		</Reference>
@@ -63,8 +36,4 @@
 			<HintPath>$(TromboneChampDir)\BepInEx\plugins\discord_game_sdk.dll</HintPath>
 		</Reference>
 	</ItemGroup>
-
-	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(TromboneTootDir)"/>
-	</Target>
 </Project>

--- a/TootTally.csproj
+++ b/TootTally.csproj
@@ -21,19 +21,4 @@
 	<ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
 	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="AutoToot">
-			<HintPath>$(TromboneChampDir)\BepInEx\plugins\AutoToot.dll</HintPath>
-		</Reference>
-		<Reference Include="HoverToot">
-			<HintPath>$(TromboneChampDir)\BepInEx\plugins\HoverToot.dll</HintPath>
-		</Reference>
-		<Reference Include="TrombSettings">
-			<HintPath>$(TromboneChampDir)\BepInEx\plugins\TrombSettings.dll</HintPath>
-		</Reference>
-		<Reference Include="DiscordSDK">
-			<HintPath>$(TromboneChampDir)\BepInEx\plugins\discord_game_sdk.dll</HintPath>
-		</Reference>
-	</ItemGroup>
 </Project>

--- a/TootTally.csproj
+++ b/TootTally.csproj
@@ -21,4 +21,8 @@
 	<ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
 	</ItemGroup>
+
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="$(TromboneTootDir) != ''">
+		<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(TromboneTootDir)"/>
+	</Target>
 </Project>

--- a/Utils/APIServices/ThunderstoreAPIService.cs
+++ b/Utils/APIServices/ThunderstoreAPIService.cs
@@ -1,7 +1,6 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using Newtonsoft.Json;
 using UnityEngine.Networking;
 
 namespace TootTally.Utils

--- a/Utils/APIServices/TootTallyAPIService.cs
+++ b/Utils/APIServices/TootTallyAPIService.cs
@@ -1,12 +1,8 @@
-﻿using BepInEx;
-using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
-using System.Net;
-using System.Text;
-using System.Threading.Tasks;
+using BepInEx;
+using Newtonsoft.Json;
 using TootTally.Graphics;
 using TootTally.Utils.Helpers;
 using UnityEngine;

--- a/Utils/APIServices/TootTallyAPIService.cs
+++ b/Utils/APIServices/TootTallyAPIService.cs
@@ -163,7 +163,7 @@ namespace TootTally.Utils
 
             if (!HasError(webRequest, false))
             {
-                var songData = JsonConvert.DeserializeObject<SerializableClass.SongInfoFromDB>(webRequest.downloadHandler.GetText()).results[0];
+                var songData = JsonConvert.DeserializeObject<SerializableClass.SongInfoFromDB>(webRequest.downloadHandler.text).results[0];
                 callback(songData);
             }
             else
@@ -183,7 +183,7 @@ namespace TootTally.Utils
             {
                 List<SerializableClass.ScoreDataFromDB> scoreList = new List<SerializableClass.ScoreDataFromDB>();
 
-                var leaderboardInfo = JsonConvert.DeserializeObject<SerializableClass.LeaderboardInfo>(webRequest.downloadHandler.GetText());
+                var leaderboardInfo = JsonConvert.DeserializeObject<SerializableClass.LeaderboardInfo>(webRequest.downloadHandler.text);
                 foreach (SerializableClass.ScoreDataFromDB score in leaderboardInfo.results)
                 {
                     scoreList.Add(score);

--- a/Utils/AssetManager.cs
+++ b/Utils/AssetManager.cs
@@ -54,7 +54,7 @@ namespace TootTally.Utils
             foreach (string assetName in requiredAssetNames)
             {
                 string assetPath = Path.Combine(assetDir, assetName);
-                Plugin.Instance.StartCoroutine(TootTallyAPIService.TryLoadingTextureLocal(assetPath, (texture) =>
+                Plugin.Instance.StartCoroutine(TootTallyAPIService.TryLoadingTextureLocal(assetPath, texture =>
                 {
                     if (texture != null)
                     {
@@ -71,7 +71,7 @@ namespace TootTally.Utils
             coroutineCount++;
             Plugin.LogInfo("Downloading asset " + assetName);
             string assetPath = Path.Combine(assetDir, assetName);
-            Plugin.Instance.StartCoroutine(TootTallyAPIService.DownloadTextureFromServer(apiLink, assetPath, (success) =>
+            Plugin.Instance.StartCoroutine(TootTallyAPIService.DownloadTextureFromServer(apiLink, assetPath, success =>
                 {
                     ReloadTextureLocal(assetDir, assetName);
                 }));
@@ -80,7 +80,7 @@ namespace TootTally.Utils
         public static void ReloadTextureLocal(string assetDir, string assetName)
         {
             string assetPath = Path.Combine(assetDir, assetName);
-            Plugin.Instance.StartCoroutine(TootTallyAPIService.TryLoadingTextureLocal(assetPath, (texture) =>
+            Plugin.Instance.StartCoroutine(TootTallyAPIService.TryLoadingTextureLocal(assetPath, texture =>
             {
                 coroutineCount--;
                 if (texture != null)

--- a/Utils/AssetManager.cs
+++ b/Utils/AssetManager.cs
@@ -1,8 +1,5 @@
-﻿using BepInEx;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using UnityEngine;
 
 namespace TootTally.Utils

--- a/Utils/Helpers/EasingHelper.cs
+++ b/Utils/Helpers/EasingHelper.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace TootTally.Utils.Helpers
 {

--- a/Utils/Helpers/FileHelper.cs
+++ b/Utils/Helpers/FileHelper.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.IO.Compression;
 using System.Text;
 

--- a/Utils/Helpers/GameObjectPathHelper.cs
+++ b/Utils/Helpers/GameObjectPathHelper.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace TootTally.Utils.Helpers
+﻿namespace TootTally.Utils.Helpers
 {
     public static class GameObjectPathHelper
     {

--- a/Utils/Helpers/SongDataHelper.cs
+++ b/Utils/Helpers/SongDataHelper.cs
@@ -79,9 +79,10 @@ namespace TootTally.Utils.Helpers
             return track is CustomTrack ? CalcFileHash(GetSongFilePath(track)) : track.trackref;
         }
 
-        public static string GenerateBaseTmb(string songFilePath, SingleTrackData singleTrackData = null)
+        public static string GenerateBaseTmb(TromboneTrack track)
         {
-            if (singleTrackData == null) singleTrackData = GlobalVariables.chosen_track_data;
+            var singleTrackData = TrackLookup.toTrackData(track);
+            var songFilePath = GetSongFilePath(track);
 
             var tmb = new SerializableClass.TMBData
             {

--- a/Utils/Helpers/SongDataHelper.cs
+++ b/Utils/Helpers/SongDataHelper.cs
@@ -1,12 +1,13 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Globalization;
+﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Security.Cryptography;
-using System.Text;
+using BaboonAPI.Hooks.Tracks;
+using Newtonsoft.Json;
+using TrombLoader.CustomTracks;
 using TrombLoader.Helpers;
 using UnityEngine;
 
@@ -53,20 +54,30 @@ namespace TootTally.Utils.Helpers
             return CalcSHA256Hash(File.ReadAllBytes(fileLocation));
         }
 
-        public static string GetSongFilePath(string trackRef)
+        public static string GetSongFilePath(TromboneTrack track)
         {
-            return Globals.IsCustomTrack(trackRef) ?
-                Path.Combine(Globals.ChartFolders[trackRef], "song.tmb") :
-                $"{Application.streamingAssetsPath}/leveldata/{trackRef}.tmb";
+            if (track is CustomTrack ct)
+            {
+                return Path.Combine(ct.folderPath, Globals.defaultChartName);
+            }
+            else
+            {
+                return $"{Application.streamingAssetsPath}/leveldata/{track.trackref}.tmb";
+            }
         }
 
         public static string GetChoosenSongHash()
         {
             string trackRef = GlobalVariables.chosen_track_data.trackref;
-            bool isCustom = Globals.IsCustomTrack(trackRef);
-            return isCustom ? GetSongHash(trackRef) : trackRef;
+            var track = TrackLookup.lookup(trackRef);
+
+            return GetSongHash(track);
         }
-        public static string GetSongHash(string trackref) => SongDataHelper.CalcFileHash(GetSongFilePath(trackref));
+
+        public static string GetSongHash(TromboneTrack track)
+        {
+            return track is CustomTrack ? CalcFileHash(GetSongFilePath(track)) : track.trackref;
+        }
 
         public static string GenerateBaseTmb(string songFilePath, SingleTrackData singleTrackData = null)
         {

--- a/Utils/PopUpNotif.cs
+++ b/Utils/PopUpNotif.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using TootTally.Utils.Helpers;
+﻿using TootTally.Utils.Helpers;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/Utils/PopUpNotifManager.cs
+++ b/Utils/PopUpNotifManager.cs
@@ -1,7 +1,5 @@
-﻿using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
+using HarmonyLib;
 using TootTally.Graphics;
 using UnityEngine;
 using UnityEngine.UI;

--- a/Utils/SerializableClass.cs
+++ b/Utils/SerializableClass.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
-using UnityEngine;
 
 namespace TootTally.Utils
 {


### PR DESCRIPTION
- Replace TrombLoader "API" (read: public methods that happened to be available at the time) calls with BaboonAPI calls
    - TrombLoader 2 stabilizes the API a bit, `folderPath` has docs and is considered API
    - ... though I'd like to do zip loading in v2.1.0, which may throw a spanner in the works. eh, we'll see
- Run "remove unused `using` directives", creating an incredibly noisy PR (ok but it was bugging me)
- Replace direct dll paths in csproj with `<PackageReference>`s
    - ~~If you want me to put that PostBuild task back just lmk~~ done